### PR TITLE
Include data corruption mitigation in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Taskswamp is a scriptlet that creates a `tmux` session with multiple `task`
 reports and allows those reports to be easily refreshed.  Each tmux window
 shows a single taskwarrior report.
 
+As of 2021/05/28, upstream taskwarrior can corrupt your data if called simultaneously.
+Taskswamp is already fixing this issue as part of https://github.com/taskswamp/taskswamp/commit/2f42a34deb0e09f37483bfa38ed56ee058597422 .
+For full compatibility with Taskswamp, you should wrap your other individual task
+to include the same locking mecanism. For example
+
+    alias task='flock ~/.task/.taskswamp.lock task'
+
 Quick start
 ===========
 


### PR DESCRIPTION
Returning to taskwarrior after a year of hiatus because of data corruption, I think now that sharing the same flock for all task warrior invocations may well be a viable solution to random file corruption like https://github.com/GothenburgBitFactory/taskwarrior/issues/2070